### PR TITLE
TypedIdentifier

### DIFF
--- a/src/validator.rs
+++ b/src/validator.rs
@@ -111,6 +111,21 @@ mod tests {
     use super::*;
 
     #[test]
+    fn identifiers() {
+        assert!(Identifier::new("foo").validate(true).is_ok());
+        assert!(Identifier::new("Foo").validate(true).is_ok());
+        assert!(Identifier::new("_foo").validate(true).is_ok());
+        assert!(Identifier::new("$foo").validate(true).is_ok());
+        assert!(Identifier::new("f00").validate(true).is_ok());
+
+        assert!(Identifier::new("foo_bar").validate(true).is_ok());
+        assert!(Identifier::new("FooBar").validate(true).is_ok());
+
+        assert!(Identifier::new("1foo").validate(true).is_err());
+        assert!(Identifier::new("#foo").validate(true).is_err());
+    }
+
+    #[test]
     fn basic_type() {
         assert!(Type::Bool.validate(true).is_ok(), "");
     }


### PR DESCRIPTION
First batch of changes from the [big PR](https://github.com/axic/yultsur/pull/5):

+ Added `TypedIdentifier`, following the grammar spec, that must have a type. Function definitions and variable declarations now use `Vec<TypedIdentifier>` instead of `Vec<Identifier>`.
+ Added `From` impls to easily create instances of `Identifier` from string literals (`"foo".into()` or `Identifier::from("foo")`).
+ `Validator` impl for `Identifier` checks that the identifier is in accordance with the grammar.
+ Changed the error type from `String` to `&'static` str in the validator, although custom `enum` or using the `error_chain` crate would be better here I reckon.